### PR TITLE
Refactor all envs to render in uint8 to save memory

### DIFF
--- a/popgym_arcade/environments/autoencode.py
+++ b/popgym_arcade/environments/autoencode.py
@@ -112,16 +112,16 @@ class AutoEncode(environment.Environment):
     """
 
     color = {
-        "red": jnp.array([1, 0, 0]),
-        "dark_red": jnp.array([0.75, 0.10, 0.10]),
-        "bright_red": jnp.array([1.0, 0.19, 0.28]),
-        "black": jnp.array([0, 0, 0]),
-        "white": jnp.array([1, 1, 1]),
-        "metallic_gold": jnp.array([0.85, 0.65, 0.13]),
-        "light_gray": jnp.array([0.96, 0.96, 0.96]),
-        "light_blue": jnp.array([0.68, 0.85, 0.90]),
-        "electric_blue": jnp.array([0.0, 0.45, 0.74]),
-        "neon_pink": jnp.array([1.0, 0.41, 0.73]),
+        "red": jnp.array([255, 0, 0], dtype=jnp.uint8),
+        "dark_red": jnp.array([191, 26, 26], dtype=jnp.uint8),
+        "bright_red": jnp.array([255, 48, 71], dtype=jnp.uint8),
+        "black": jnp.array([0, 0, 0], dtype=jnp.uint8),
+        "white": jnp.array([255, 255, 255], dtype=jnp.uint8),
+        "metallic_gold": jnp.array([217, 166, 33], dtype=jnp.uint8),
+        "light_gray": jnp.array([245, 245, 245], dtype=jnp.uint8),
+        "light_blue": jnp.array([173, 217, 230], dtype=jnp.uint8),
+        "electric_blue": jnp.array([0, 115, 189], dtype=jnp.uint8),
+        "neon_pink": jnp.array([255, 105, 186], dtype=jnp.uint8),
     }
     size={
         256: {
@@ -207,9 +207,9 @@ class AutoEncode(environment.Environment):
         self.num_decks = num_decks
         self.canvas_size = self.size[obs_size]["canvas_size"]
         self.canvas_color = self.color["light_blue"]
-        self.large_canvas = jnp.ones((self.canvas_size, self.canvas_size, 3)) * self.canvas_color
+        self.large_canvas = jnp.full((self.canvas_size, self.canvas_size, 3), self.canvas_color, dtype=jnp.uint8)
         self.small_canvas_size = self.size[obs_size]["small_canvas_size"]
-        self.small_canvas = jnp.ones((self.small_canvas_size, self.small_canvas_size, 3)) * self.canvas_color
+        self.small_canvas = jnp.full((self.small_canvas_size, self.small_canvas_size, 3), self.canvas_color, dtype=jnp.uint8)
 
 
         self.max_steps_in_episode = 140 + self.decksize * self.num_decks
@@ -417,7 +417,7 @@ class AutoEncode(environment.Environment):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(jnp.array(0, ), jnp.array(1, ), (256, 256, 3), dtype=jnp.float32)
+        return spaces.Box(0, 255, (256, 256, 3), dtype=jnp.uint8)
 
 
 class AutoEncodeEasy(AutoEncode):

--- a/popgym_arcade/environments/battleship.py
+++ b/popgym_arcade/environments/battleship.py
@@ -165,66 +165,69 @@ class BattleShip(environment.Environment):
     partial_obs: bool switch with POMDP and FOMDP.
     """
 
+    render_common = {
+        # parameters for rendering (256, 256, 3) canvas
+        "clr": jnp.array([255, 255, 255], dtype=jnp.uint8),
+        "sub_clr": jnp.array([191, 191, 191], dtype=jnp.uint8),
+        # parameters for rendering grids
+        "grid_clr": jnp.array([102, 102, 102], dtype=jnp.uint8),
+        # parameters for rendering current action position
+        "action_clr": jnp.array([217, 166, 33], dtype=jnp.uint8),
+        # parameters for render hit ship grids
+        "x_clr": jnp.array([255, 0, 0], dtype=jnp.uint8),
+        # parameters for render hit enpty grids
+        "o_clr": jnp.array([0, 0, 0], dtype=jnp.uint8),
+        # parameters for render score
+        "sc_clr": jnp.array([255, 128, 0], dtype=jnp.uint8),
+        # parameters for render env name
+        "env_clr": jnp.array([74, 214, 247], dtype=jnp.uint8),
+        
+    }
+
     render_256x = {
+        **render_common,
         # parameters for rendering (256, 256, 3) canvas
         "size": 256,
-        "clr": jnp.array([1.0, 1.0, 1.0]),
         "sub_size": {
             8: 186,
             10: 192,
             12: 182,
         },
-        "sub_clr": jnp.array([0.75, 0.75, 0.75]),
         # parameters for rendering grids
         "grid_px": 2,
-        "grid_clr": jnp.array([0.4, 0.4, 0.4]),
-        # parameters for rendering current action position
-        "action_clr": jnp.array([0.85, 0.65, 0.13]),
         # parameters for render hit ship grids
         "x_px": 2,
-        "x_clr": jnp.array([1.0, 0.0, 0.0]),
         # parameters for render hit enpty grids
         "o_px": 2,
-        "o_clr": jnp.array([0.0, 0.0, 0.0]),
         # parameters for render score
         "sc_t_l": (86, 2),
         "sc_b_r": (171, 30),
-        "sc_clr": jnp.array([1.0, 0.5, 0.0]),
         # parameters for render env name
         "env_t_l": (0, 231),
         "env_b_r": (256, 256),
-        "env_clr": jnp.array([0.29, 0.84, 0.97]),
     }
 
     render_128x = {
+        **render_common,
         # parameters for rendering (128, 128, 3) canvas
         "size": 128,
-        "clr": jnp.array([1.0, 1.0, 1.0]),
         "sub_size": {
             8: 90,
             10: 92,
             12: 98,
         },
-        "sub_clr": jnp.array([0.75, 0.75, 0.75]),
         # parameters for rendering grids
         "grid_px": 2,
-        "grid_clr": jnp.array([0.4, 0.4, 0.4]),
-        # parameters for rendering current action position
-        "action_clr": jnp.array([0.85, 0.65, 0.13]),
         # parameters for render hit ship grids
         "x_px": 1,
-        "x_clr": jnp.array([1.0, 0.0, 0.0]),
         # parameters for render hit enpty grids
         "o_px": 1,
-        "o_clr": jnp.array([0.0, 0.0, 0.0]),
         # parameters for rendering score
         "sc_t_l": (43, 1),
         "sc_b_r": (85, 15),
-        "sc_clr": jnp.array([0.0, 1.0, 0.5]),
         # parameters for rendering envName
         "env_t_l": (0, 115),
         "env_b_r": (128, 128),
-        "env_clr": jnp.array([0.29, 0.84, 0.97]),
     }
     render_mode = {
         256: render_256x,
@@ -430,7 +433,8 @@ class BattleShip(environment.Environment):
         # Initialize canvases
         canvas = jnp.full(
             (render_config["size"], render_config["size"], 3),
-            render_config["clr"]
+            render_config["clr"],
+            dtype=jnp.uint8,
         )
         sub_canvas = jnp.full(
             (
@@ -438,7 +442,8 @@ class BattleShip(environment.Environment):
                 render_config["sub_size"][board_size],
                 3,
             ),
-            render_config["sub_clr"]
+            render_config["sub_clr"],
+            dtype=jnp.uint8,
         )
 
         # Extract action coordinates
@@ -555,7 +560,7 @@ class BattleShip(environment.Environment):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(jnp.zeros((0,)), jnp.ones((1,)), (256, 256, 3), dtype=jnp.float32)
+        return spaces.Box(0, 255, (256, 256, 3), dtype=jnp.uint8)
 
 
 class BattleShipEasy(BattleShip):

--- a/popgym_arcade/environments/cartpole.py
+++ b/popgym_arcade/environments/cartpole.py
@@ -94,68 +94,72 @@ class CartPole(environment.Environment[EnvState, EnvParams]):
     max_steps_in_episode: max steps agent can play in each episode.
     """
 
+    render_common = {
+        # parameters for rendering (256, 256, 3) canvas
+        "clr": jnp.array([51, 51, 51], dtype=jnp.uint8),
+        "sub_clr": jnp.array([51, 51, 51], dtype=jnp.uint8),
+        # parameters for rendering cart
+        "cart_clr": jnp.array([245, 74, 140], dtype=jnp.uint8),
+        # parameters for rendering pole
+        "pole_clr": jnp.array([140, 69, 18], dtype=jnp.uint8),
+        # parameters for rendering harrow
+        "harrow_clr": jnp.array([204, 204, 204], dtype=jnp.uint8),
+        # parameters for rendering carrow
+        "carrow_clr": jnp.array([204, 204, 204], dtype=jnp.uint8),
+        # parameters for rendering score
+        "sc_clr": jnp.array([0, 255, 128], dtype=jnp.uint8),
+        # parameters for rendering envName
+        "env_clr": jnp.array([74, 214, 247], dtype=jnp.uint8),
+    }
+
     render_256x = {
+        **render_common,
         # parameters for rendering (256, 256, 3) canvas
         "size": 256,
-        "clr": jnp.array([0.2, 0.2, 0.2]),
         "sub_size": 192,
-        "sub_clr": jnp.array([0.2, 0.2, 0.2]),
         # parameters for rendering cart
         "cart_w": 64,
         "cart_h": 32,
         "cart_pos": 96,
-        "cart_clr": jnp.array([0.96, 0.29, 0.55]),
         # parameters for rendering pole
-        "pole_clr": jnp.array([0.55, 0.27, 0.07]),
         "pole_px": 5,
         # parameters for rendering harrow
         "harrow_t_l": (10, 138),
         "harrow_b_r": (54, 182),
-        "harrow_clr": jnp.array([0.8, 0.8, 0.8]),
         # parameters for rendering carrow
         "carrow_t_l": (138, 138),
         "carrow_b_r": (182, 182),
-        "carrow_clr": jnp.array([0.8, 0.8, 0.8]),
         # parameters for rendering score
         "sc_t_l": (86, 2),
         "sc_b_r": (171, 30),
-        "sc_clr": jnp.array([0.0, 1.0, 0.5]),
         # parameters for rendering envName
         "env_t_l": (0, 231),
         "env_b_r": (256, 256),
-        "env_clr": jnp.array([0.29, 0.84, 0.97]),
     }
 
     render_128x = {
+        **render_common,
         # parameters for rendering (128, 128, 3) canvas
         "size": 128,
-        "clr": jnp.array([0.2, 0.2, 0.2]),
         "sub_size": 96,
-        "sub_clr": jnp.array([0.2, 0.2, 0.2]),
         # parameters for rendering cart
         "cart_w": 32,
         "cart_h": 16,
         "cart_pos": 48,
-        "cart_clr": jnp.array([0.96, 0.29, 0.55]),
         # parameters for rendering pole
-        "pole_clr": jnp.array([0.55, 0.27, 0.07]),
         "pole_px": 3,
         # parameters for rendering harrow
         "harrow_t_l": (5, 69),
         "harrow_b_r": (27, 91),
-        "harrow_clr": jnp.array([0.8, 0.8, 0.8]),
         # parameters for rendering carrow
         "carrow_t_l": (69, 69),
         "carrow_b_r": (91, 91),
-        "carrow_clr": jnp.array([0.8, 0.8, 0.8]),
         # parameters for rendering score
         "sc_t_l": (43, 1),
         "sc_b_r": (85, 15),
-        "sc_clr": jnp.array([0.0, 1.0, 0.5]),
         # parameters for rendering envName
         "env_t_l": (0, 115),
         "env_b_r": (128, 128),
-        "env_clr": jnp.array([0.29, 0.84, 0.97]),
     }
     render_mode = {
         256: render_256x,
@@ -366,11 +370,13 @@ class CartPole(environment.Environment[EnvState, EnvParams]):
 
         # Initialize canvas and sub-canvas
         canvas = jnp.zeros(
-            (render_config["size"], render_config["size"], 3)
+            (render_config["size"], render_config["size"], 3),
+            dtype=jnp.uint8
         ) + render_config["clr"]
 
         sub_canvas = jnp.zeros(
-            (render_config["sub_size"], render_config["sub_size"], 3)
+            (render_config["sub_size"], render_config["sub_size"], 3),
+            dtype=jnp.uint8
         ) + render_config["sub_clr"]
 
         # Add noise to the state
@@ -520,7 +526,7 @@ class CartPole(environment.Environment[EnvState, EnvParams]):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(jnp.array(0, ), jnp.array(1, ), (self.obs_size, self.obs_size, 3), dtype=jnp.float32)
+        return spaces.Box(0, 255, (self.obs_size, self.obs_size, 3), dtype=jnp.uint8)
 
     def state_space(self, params: EnvParams) -> spaces.Dict:
         """State space of the environment."""

--- a/popgym_arcade/environments/countrecall.py
+++ b/popgym_arcade/environments/countrecall.py
@@ -118,22 +118,23 @@ class CountRecall(environment.Environment):
     """
 
     color = {
-        "red": jnp.array([1, 0, 0]),
-        "dark_red": jnp.array([0.75, 0.10, 0.10]),
-        "black": jnp.array([0, 0, 0]),
-        "white": jnp.array([1, 1, 1]),
-        "light_blue": jnp.array([0.29, 0.75, 0.94]),
-        "dark_blue": jnp.array([0.12, 0.47, 0.77]),
-        "soft_green": jnp.array([0.56, 0.93, 0.56]),
-        "green": jnp.array([0.56, 0.93, 0.56]),
-        "soft_beige": jnp.array([0.96, 0.88, 0.79]),
-        "olive_green": jnp.array([0.5, 0.63, 0.39]),
-        "maroon": jnp.array([0.69, 0.19, 0.38]),
-        "teal": jnp.array([0.0, 0.5, 0.5]),
-        "light_gray": jnp.array([0.96, 0.96, 0.96]),
-        "bright_blue": jnp.array([0.29, 0.75, 0.94]),
-        "muted_blue": jnp.array([0.6, 0.7, 0.8]),
+        "red": jnp.array([255, 0, 0], dtype=jnp.uint8),
+        "dark_red": jnp.array([191, 26, 26], dtype=jnp.uint8),
+        "black": jnp.array([0, 0, 0], dtype=jnp.uint8),
+        "white": jnp.array([255, 255, 255], dtype=jnp.uint8),
+        "light_blue": jnp.array([74, 191, 240], dtype=jnp.uint8),
+        "dark_blue": jnp.array([31, 120, 196], dtype=jnp.uint8),
+        "soft_green": jnp.array([143, 237, 143], dtype=jnp.uint8),
+        "green": jnp.array([143, 237, 143], dtype=jnp.uint8),
+        "soft_beige": jnp.array([245, 224, 201], dtype=jnp.uint8),
+        "olive_green": jnp.array([128, 161, 99], dtype=jnp.uint8),
+        "maroon": jnp.array([176, 48, 97], dtype=jnp.uint8),
+        "teal": jnp.array([0, 128, 128], dtype=jnp.uint8),
+        "light_gray": jnp.array([245, 245, 245], dtype=jnp.uint8),
+        "bright_blue": jnp.array([74, 191, 240], dtype=jnp.uint8),
+        "muted_blue": jnp.array([153, 179, 204], dtype=jnp.uint8),
     }
+
     size = {
         256 :{
             "canvas_size" : 256,
@@ -249,8 +250,8 @@ class CountRecall(environment.Environment):
         self.canvas_size = self.size[obs_size]["canvas_size"]
         self.small_canvas_size = self.size[obs_size]["small_canvas_size"]
         self.canvas_color = self.color["light_gray"]
-        self.large_canvas = jnp.zeros((self.canvas_size, self.canvas_size, 3)) + self.canvas_color
-        self.small_canvas = jnp.zeros((self.small_canvas_size, self.small_canvas_size, 3)) + self.color["muted_blue"]
+        self.large_canvas = jnp.zeros((self.canvas_size, self.canvas_size, 3), dtype=jnp.uint8) + self.canvas_color
+        self.small_canvas = jnp.zeros((self.small_canvas_size, self.small_canvas_size, 3), dtype=jnp.uint8) + self.color["muted_blue"]
 
         self.setup_render_templates()
 
@@ -467,7 +468,7 @@ class CountRecall(environment.Environment):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(jnp.array(0,), jnp.array(1,), (256, 256, 3), dtype=jnp.float32)
+        return spaces.Box(0, 255, (256, 256, 3), dtype=jnp.uint8)
 
 
 class CountRecallEasy(CountRecall):

--- a/popgym_arcade/environments/draw_utils.py
+++ b/popgym_arcade/environments/draw_utils.py
@@ -739,9 +739,9 @@ def draw_tnt_block(
     inner_block_mask = jnp.outer(inner_mask_y, inner_mask_x)
 
     # Prepare color arrays
-    red_color = jnp.array([1.0, 0.0, 0.0])  # Bright red
-    white_color = jnp.array([1.0, 1.0, 1.0])  # White
-    black_color = jnp.array([0.0, 0.0, 0.0])  # Black
+    red_color = jnp.array([255, 0, 0], dtype=jnp.uint8)  # Bright red
+    white_color = jnp.array([255, 255, 255], dtype=jnp.uint8)  # White
+    black_color = jnp.array([0, 0, 0], dtype=jnp.uint8)  # Black
 
     # Create a preliminary canvas with the red background
     red_canvas = jnp.where(full_block_mask[:, :, None], red_color, canvas)
@@ -1074,8 +1074,8 @@ def draw_digit(
     yy, xx = jnp.meshgrid(y_indices, x_indices, indexing='ij')
 
     # Compute the cell indices for each pixel
-    cell_x = ((xx - top_x) // width).astype(int)
-    cell_y = ((yy - top_y) // height).astype(int)
+    cell_x = ((xx - top_x) // width).astype(jnp.uint8)
+    cell_y = ((yy - top_y) // height).astype(jnp.uint8)
 
     # Create a mask for valid cells
     valid_cells = (
@@ -1991,15 +1991,15 @@ def draw_words_h(
     total_width = num_letters * letter_width + (num_letters - 1) * space
     start_col = top_x + (bottom_x - top_x - total_width) // 2
 
-    indices = jnp.arange(num_letters)
+    indices = jnp.arange(num_letters, dtype=jnp.uint8)
     current_cols = start_col + indices * (letter_width + space)
     top_left_letters = jnp.stack([
         current_cols,
-        jnp.full(num_letters, top_y + margin)
+        jnp.full(num_letters, top_y + margin, dtype=jnp.uint8)
     ], axis=1)
     bottom_right_letters = jnp.stack([
         current_cols + letter_width,
-        jnp.full(num_letters, bottom_y - margin)
+        jnp.full(num_letters, bottom_y - margin, dtype=jnp.uint8)
     ], axis=1)
 
     def compute_delta(letter_code, top_left, bottom_right):
@@ -2010,9 +2010,9 @@ def draw_words_h(
             letter_code
         )
         return modified_canvas - canvas
-
+    
     deltas = jax.vmap(compute_delta)(letters, top_left_letters, bottom_right_letters)
-    final_canvas = canvas + jnp.sum(deltas, axis=0)
+    final_canvas = canvas + jnp.sum(deltas, axis=0, dtype=jnp.uint8)
     return final_canvas
 
 
@@ -2043,11 +2043,11 @@ def draw_words_v(
     indices = jnp.arange(num_letters)
     current_rows = start_row + indices * (letter_width + space)
     top_left_letters = jnp.stack([
-        jnp.full(num_letters, top_x + margin),
+        jnp.full(num_letters, top_x + margin, dtype=jnp.uint8),
         current_rows
     ], axis=1)
     bottom_right_letters = jnp.stack([
-        jnp.full(num_letters, bottom_x - margin),
+        jnp.full(num_letters, bottom_x - margin, dtype=jnp.uint8),
         current_rows + letter_width
     ], axis=1)
 
@@ -2062,7 +2062,7 @@ def draw_words_v(
         return modified_canvas - canvas
 
     deltas = jax.vmap(compute_delta)(letters, top_left_letters, bottom_right_letters)
-    final_canvas = canvas + jnp.sum(deltas, axis=0)
+    final_canvas = canvas + jnp.sum(deltas, axis=0, dtype=jnp.uint8)
     return final_canvas
 
 
@@ -2081,7 +2081,7 @@ def draw_str(
     # Convert string to ASCII codes with vectorized uppercase conversion
     arr = jnp.frombuffer(word.encode('ascii'), dtype=jnp.uint8)
     mask = (arr >= ord('a')) & (arr <= ord('z'))
-    letter = jnp.where(mask, arr - 32, arr).astype(jnp.int32)
+    letter = jnp.where(mask, arr - 32, arr).astype(jnp.uint8)
 
     return lax.cond(
         horizontal,

--- a/popgym_arcade/environments/navigator.py
+++ b/popgym_arcade/environments/navigator.py
@@ -177,58 +177,58 @@ class Navigator(environment.Environment):
 
     """
 
+    render_common = {
+        # parameters for rendering (256, 256, 3) canvas
+        "clr": jnp.array([119, 122, 127], dtype=jnp.uint8),
+        "sub_clr": jnp.array([119, 112, 127], dtype=jnp.uint8),
+        # parameters for rendering grids
+        "grid_clr": jnp.array([255, 255, 255], dtype=jnp.uint8),
+        # parameters for current action position
+        "action_clr": jnp.array([255, 255, 0], dtype=jnp.uint8),
+        # parameters for rendering treasure
+        "trea_clr": jnp.array([73, 214, 247], dtype=jnp.uint8),
+        # parameters for rendering score
+        "sc_clr": jnp.array([0, 0, 127], dtype=jnp.uint8),
+        # parameters for rendering env name
+        "env_clr": jnp.array([138, 0, 138], dtype=jnp.uint8),
+
+    }
     render_256x = {
+        **render_common,
         # parameters for rendering (256, 256, 3) canvas
         "size": 256,
-        "clr": jnp.array([0.47, 0.48, 0.5]),
         "sub_size": {
             8: 186,
             10: 192,
             12: 182,
         },
-        "sub_clr": jnp.array([0.47, 0.48, 0.5]),
-        # parameters for current action position
-        "action_clr": jnp.array([1, 1, 0]),
-        # parameters for rendering treasure
-        "trea_clr": jnp.array([0.29, 0.84, 0.97]),
         # parameters for rendering grids
         "grid_px": 2,
-        "grid_clr": jnp.array([1, 1, 1]),
         # parameters for rendering score
         "sc_t_l": (86, 2),
         "sc_b_r": (171, 30),
-        "sc_clr": jnp.array([0, 0, 0.5]),
         # parameters for rendering env name
         "env_t_l": (0, 231),
         "env_b_r": (256, 256),
-        "env_clr": jnp.array([0.545, 0.0, 0.545]),
     }
 
     render_128x = {
+        **render_common,
         # parameters for rendering (128, 128, 3) canvas
         "size": 128,
-        "clr": jnp.array([0.47, 0.48, 0.5]),
         "sub_size": {
             8: 90,
             10: 92,
             12: 98,
         },
-        "sub_clr": jnp.array([0.47, 0.48, 0.5]),
-        # parameters for current action position
-        "action_clr": jnp.array([1, 1, 0]),
-        # parameters for rendering treasure
-        "trea_clr": jnp.array([0.29, 0.84, 0.97]),
         # parameters for rendering grids
         "grid_px": 2,
-        "grid_clr": jnp.array([1, 1, 1]),
         # parameters for rendering score
         "sc_t_l": (43, 1),
         "sc_b_r": (85, 15),
-        "sc_clr": jnp.array([0.0, 1.0, 0.5]),
         # parameters for rendering envName
         "env_t_l": (0, 115),
         "env_b_r": (128, 128),
-        "env_clr": jnp.array([0.29, 0.84, 0.97]),
     }
     render_mode = {
         256: render_256x,
@@ -602,7 +602,7 @@ class Navigator(environment.Environment):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(jnp.zeros((0,)), jnp.ones((1,)), (self.obs_size, self.obs_size, 3), dtype=jnp.float32)
+        return spaces.Box(0, 255, (self.obs_size, self.obs_size, 3), dtype=jnp.uint8)
 
 
 class NavigatorEasy(Navigator):

--- a/popgym_arcade/environments/skittles.py
+++ b/popgym_arcade/environments/skittles.py
@@ -32,10 +32,10 @@ class EnvParams(environment.EnvParams):
 
 class Skittles(environment.Environment[EnvState, EnvParams]):
     """
-    Jax compilable environment for the Swimming Dragon.
+    Jax compilable environment for Skittles.
     
     ### Description
-    In Swimming Dragon, the agent is tasked with avoiding enemies that fall from the top of the screen.
+    In Skittles, the agent is tasked with avoiding enemies that fall from the top of the screen.
     The agent can move left or right to dodge the enemies. The goal is to survive as long as possible without being hit by an enemy.
     There are three difficulties: easy, medium, and hard. Each difficulty has a different grid size and maximum steps in an episode.
     Easy: 8x8 grid, agent's goal is to survive 200 steps, have 1 enemy in each row
@@ -82,86 +82,64 @@ class Skittles(environment.Environment[EnvState, EnvParams]):
 
     """
 
+    render_common = {
+        # parameters for rendering (256, 256, 3) canvas
+        "clr": jnp.array([0, 0, 0], dtype=jnp.uint8),
+        # parameters for rendering sub canvas
+        "sub_clr": jnp.array([0, 0, 0], dtype=jnp.uint8),
+        # parameters for current action position
+        "action_clr": jnp.array([255, 255, 255], dtype=jnp.uint8),
+        # parameters for rendering enemy
+        "red": jnp.array([255, 0, 0], dtype=jnp.uint8),
+        "orange": jnp.array([255, 128, 0], dtype=jnp.uint8),
+        "yellow": jnp.array([255, 255, 0], dtype=jnp.uint8),
+        "green": jnp.array([0, 255, 0], dtype=jnp.uint8),
+        "blue": jnp.array([0, 0, 255], dtype=jnp.uint8),
+        "indigo": jnp.array([74, 214, 247], dtype=jnp.uint8),
+        "violet": jnp.array([125, 0, 235], dtype=jnp.uint8),
+        # parameters for rendering grids
+        "grid_clr": jnp.array([255, 255, 255], dtype=jnp.uint8),
+        # parameters for rendering score
+        "sc_clr": jnp.array([0, 255, 128], dtype=jnp.uint8),
+        # parameters for rendering env name
+        "env_clr": jnp.array([255, 245, 0], dtype=jnp.uint8),
+    }
     render_256x = {
+        **render_common,
         # parameters for rendering (256, 256, 3) canvas
         "size": 256,
-        "clr": jnp.array([0.0, 0.0, 0.0]),
         "sub_size": {
             8: 186,
             10: 192,
             12: 182,
         },
-        # parameters for rendering sub canvas
-        "sub_clr": jnp.array([0.0, 0.0, 0.0]),
-        
-        # parameters for current action position
-        "action_clr": jnp.array([1.0, 1.0, 1.0]),
-        
-        # parameters for rendering enemy
-        # "enemy_clr": jnp.array([0.29, 0.84, 0.97]),
-        # rainbow color
-        "red": jnp.array([1.0, 0.0, 0.0]),
-        "orange": jnp.array([1.0, 0.5, 0.0]),
-        "yellow": jnp.array([1.0, 1.0, 0.0]),
-        "green": jnp.array([0.0, 1.0, 0.0]),
-        "blue": jnp.array([0.0, 0.0, 1.0]),
-        "indigo": jnp.array([0.29, 0.84, 0.97]),
-        "violet": jnp.array([0.49, 0.0, 0.92]),
-
         # parameters for rendering grids
         "grid_px": 2,
-        "grid_clr": jnp.array([1.0, 1.0, 1.0]),
-
         # parameters for rendering score
         "sc_t_l": (86, 2),
         "sc_b_r": (171, 30),
-        "sc_clr": jnp.array([0.0, 1.0, 0.5]),
-        
         # parameters for rendering env name
         "env_t_l": (0, 231),
         "env_b_r": (256, 256),
-        "env_clr": jnp.array([1.0, 0.96, 0.0]),
     }
 
     render_128x = {
+        **render_common,
         # parameters for rendering (128, 128, 3) canvas
         "size": 128,
-        "clr": jnp.array([0.0, 0.0, 0.0]),
         "sub_size": {
             8: 90,
             10: 92,
             12: 98,
         },
-        # parameters for rendering sub canvas
-        "sub_clr": jnp.array([0.0, 0.0, 0.0]),
-        
-        # parameters for current action position
-        "action_clr": jnp.array([1.0, 1.0, 1.0]),
-        
-        # parameters for rendering enemy
-        # "enemy_clr": jnp.array([0.29, 0.84, 0.97]),
-        # rainbow color
-        "red": jnp.array([1.0, 0.0, 0.0]),
-        "orange": jnp.array([1.0, 0.5, 0.0]),
-        "yellow": jnp.array([1.0, 1.0, 0.0]),
-        "green": jnp.array([0.0, 1.0, 0.0]),
-        "blue": jnp.array([0.0, 0.0, 1.0]),
-        "indigo": jnp.array([0.29, 0.84, 0.97]),
-        "violet": jnp.array([0.49, 0.0, 0.92]),
-
         # parameters for rendering grids
         "grid_px": 2,
-        "grid_clr": jnp.array([1.0, 1.0, 1.0]),
-
         # parameters for rendering score
         "sc_t_l": (43, 1),
         "sc_b_r": (85, 15),
-        "sc_clr": jnp.array([0.0, 1.0, 0.5]),
-        
         # parameters for rendering env name
         "env_t_l": (0, 115),
         "env_b_r": (128, 128),
-        "env_clr": jnp.array([1.0, 0.96, 0.0]),
     }
     render_mode = {
         256: render_256x,
@@ -251,7 +229,7 @@ class Skittles(environment.Environment[EnvState, EnvParams]):
         """Reset the environment to an initial state."""
         key, subkey1 = jax.random.split(key)
         matrix_state = jnp.zeros((self.grid_size, self.grid_size), dtype=jnp.int32)
-        x = jax.random.randint(subkey1, shape=(), minval=0, maxval=self.grid_size).astype(jnp.int32) 
+        x = jax.random.randint(subkey1, shape=(), minval=0, maxval=self.grid_size, dtype=jnp.int32)
 
         state = EnvState(
             matrix_state = matrix_state,
@@ -307,11 +285,13 @@ class Skittles(environment.Environment[EnvState, EnvParams]):
         # Initialize canvases
         canvas = jnp.full(
             (render_config["size"],) * 2 + (3,),
-            render_config["clr"]
+            render_config["clr"],
+            dtype=jnp.uint8
         )
         sub_canvas = jnp.full(
             (sub_size, sub_size, 3), 
-            render_config["sub_clr"]
+            render_config["sub_clr"],
+            dtype=jnp.uint8
         )
 
         action_x, action_y = board_size - 1, state.x
@@ -428,7 +408,7 @@ class Skittles(environment.Environment[EnvState, EnvParams]):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(jnp.zeros((0,)), jnp.ones((1,)), (self.obs_size, self.obs_size, 3), dtype=jnp.float32)
+        return spaces.Box(0, 255, (self.obs_size, self.obs_size, 3), dtype=jnp.uint8)
 
 
 class SkittlesEasy(Skittles):

--- a/popgym_arcade/play.py
+++ b/popgym_arcade/play.py
@@ -26,7 +26,7 @@ def parse_args():
 
 def to_surf(arr):
     # Convert jax arry to pygame surface
-    return np.transpose(np.array(arr* 255).astype(np.uint8), (1, 0, 2))
+    return np.transpose(arr, (1, 0, 2))
 
 def play(args):
     # Create env env variant
@@ -51,6 +51,7 @@ def play(args):
     running = True
 
     # Convert numpy array to Pygame surface
+    print(observation.dtype)
     surface = pygame.surfarray.make_surface(to_surf(observation))
 
     # Action mappings (modify based on your environment's action space)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,6 +37,8 @@ def test_reset_and_step_short(env_name, partial, obs_size):
         # Step the env to the next state
         # No need to reset, gymnax automatically resets when done
         observation, env_state, reward, done, info = step(step_keys, env_state, actions, env_params)
+        # Check obs space is correct
+        assert env.observation_space(env_params).contains(observation), "Invalid observation space"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, all envs rendered float32 pixels. By changing them to uint8, we should save quite a bit of memory.